### PR TITLE
Increase maximum file upload size

### DIFF
--- a/app.js
+++ b/app.js
@@ -340,7 +340,7 @@
 
     const validateImageFile = (file) => {
         if (!file.type.startsWith('image/')) return { valid: false, message: 'Please select a valid image file (JPG, PNG, WebP, AVIF)' };
-        if (file.size > 50 * 1024 * 1024) return { valid: false, message: 'Image file size must be less than 50MB' };
+        if (file.size > 300 * 1024 * 1024) return { valid: false, message: 'Image file size must be less than 300MB' };
         return { valid: true };
     };
 
@@ -348,7 +348,7 @@
         const type = (file && file.type) ? file.type.toLowerCase() : '';
         const name = (file && file.name) ? file.name.toLowerCase() : '';
         if (!type.includes('png') && !name.endsWith('.png')) return { valid: false, message: 'Watermark must be a PNG file' };
-        if (file.size > 10 * 1024 * 1024) return { valid: false, message: 'Watermark file size must be less than 10MB' };
+        if (file.size > 50 * 1024 * 1024) return { valid: false, message: 'Watermark file size must be less than 50MB' };
         return { valid: true };
     };
 


### PR DESCRIPTION
Increase main image file upload limit to 300MB and watermark file limit to 50MB to support larger, higher-resolution files.

---
<a href="https://cursor.com/background-agent?bcId=bc-65b81db8-483a-4295-914b-9c6b99dc9004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65b81db8-483a-4295-914b-9c6b99dc9004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

